### PR TITLE
Fix dupe text bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "$(npm bin)/eslint src test",
     "test": "$(npm bin)/mocha --compilers js:babel-register && npm run lint",
-    "test-dev": "$(npm bin)/mocha --watch",
+    "test-dev": "$(npm bin)/mocha --compilers js:babel-register --watch",
     "test-brk": "$(npm bin)/mocha --debug-brk",
     "compile": "rm -rf dist && mkdir dist && babel src --out-file dist/index.js",
     "prepublish": "npm run compile"

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ The following inline styles are supported:
 - italic
 - H1 - H6
 
-The following block syles are supported:
+The following block styles are supported:
 
 - ordered list
 - unordered list

--- a/src/draftjsToMd.js
+++ b/src/draftjsToMd.js
@@ -76,21 +76,24 @@ function fixWhitespacesInsideStyle(text, style) {
   // Text between opening and closing markers
   const body = text.slice(style.range.start, style.range.end);
   // Trimmed text between markers
-  const bodyT = body.trim();
+  const bodyTrimmed = body.trim();
   // Text after closing marker
   const post = text.slice(style.range.end);
 
+  const bodyTrimmedStart = style.range.start + body.indexOf(bodyTrimmed);
+
   // Text between opening marker and trimmed content (leading spaces)
-  const prefix = text.slice(style.range.start, text.indexOf(bodyT));
+  const prefix = text.slice(style.range.start, bodyTrimmedStart);
   // Text between the end of trimmed content and closing marker (trailing spaces)
-  const postfix = text.slice(text.indexOf(bodyT) + bodyT.length, style.range.end);
+  const postfix = text.slice(bodyTrimmedStart + bodyTrimmed.length, style.range.end);
+
 
   // Temporary text that contains trimmed content wrapped into original pre- and post-texts
-  const newText = `${pre}${bodyT}${post}`;
+  const newText = `${pre}${bodyTrimmed}${post}`;
   // Insert leading and trailing spaces between pre-/post- contents and their respective markers
   return newText.replace(
-      `${symbol}${bodyT}${symbol}`,
-      `${prefix}${symbol}${bodyT}${symbol}${postfix}`);
+      `${symbol}${bodyTrimmed}${symbol}`,
+      `${prefix}${symbol}${bodyTrimmed}${symbol}${postfix}`);
 }
 
 function draftjsToMd(raw, extraMarkdownDict) {

--- a/test/draftjsToMd.test.js
+++ b/test/draftjsToMd.test.js
@@ -497,6 +497,26 @@ describe('draftjsToMd', () => {
     draftjsToMd(raw).should.equal(expectedMarkdown);
   });
 
+  it('handles leading and trailing spaces around styled text without duplicating string', () => {
+    const raw = {
+      blocks: [{
+        text: 'this is a test',
+        type: 'unstyled',
+        depth: 0,
+        inlineStyleRanges: [
+          {
+            offset: 5,
+            length: 2,
+            style: 'BOLD'
+          },
+        ],
+        entityRanges: []
+      }]
+    };
+    const expectedMarkdown = 'this __is__ a test';
+    draftjsToMd(raw).should.equal(expectedMarkdown);
+  });
+
   describe('custom markdownDict', () => {
     const customMarkdownDict = {
       BOLD: '**',


### PR DESCRIPTION
## Overview

This PR fixes a bug where duplicate text was being inserted when converting from draftjs to markdown.

Closes #14 