### PR TITLE
Allow adding style for lowest level children

### DIFF
--- a/src/mdToDraftjs.js
+++ b/src/mdToDraftjs.js
@@ -180,7 +180,8 @@ const parseMdLine = (line, existingEntities, extraStyles = {}) => {
     } else {
       if (style) {
         addInlineStyleRange(text.length, child.value.length, style.type);
-      } else if (inlineStyles[child.type]) {
+      }
+      if (inlineStyles[child.type]) {
         addInlineStyleRange(text.length, child.value.length, inlineStyles[child.type].type);
       }
       text = `${text}${

--- a/src/mdToDraftjs.js
+++ b/src/mdToDraftjs.js
@@ -180,8 +180,7 @@ const parseMdLine = (line, existingEntities, extraStyles = {}) => {
     } else {
       if (style) {
         addInlineStyleRange(text.length, child.value.length, style.type);
-      }
-      if (inlineStyles[child.type]) {
+      } else if (inlineStyles[child.type]) {
         addInlineStyleRange(text.length, child.value.length, inlineStyles[child.type].type);
       }
       text = `${text}${

--- a/test/mdToDraftjs.test.js
+++ b/test/mdToDraftjs.test.js
@@ -763,4 +763,33 @@ describe('mdToDraftjs', () => {
 
     mdToDraftjs(markdown, customDict).should.deep.equal(expectedDraftjs);
   });
+  it('parses inline code mixed with other styles correctly', () => {
+    const markdown = '__`code`__';
+    const expectedDraftjs = {
+      blocks: [
+        {
+          text: 'code',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [
+            { offset: 0, length: 4, style: 'BOLD' },
+            { offset: 0, length: 4, style: 'CODE' }
+          ],
+          entityRanges: []
+        }
+      ],
+      entityMap: { data: '', mutability: '', type: '' }
+    };
+
+    const customDict = {
+      inlineStyles: {
+        Code: {
+          type: 'CODE',
+          symbol: '`'
+        }
+      }
+    };
+
+    mdToDraftjs(markdown, customDict).should.deep.equal(expectedDraftjs);
+  });
 });


### PR DESCRIPTION
Style for inline-code in markdown get skipped in case they are surrounded by other styles due to them not having children. (https://astexplorer.net/#/gist/54261123dce2532e40b7382314d0b8fe/39bcfe0e832e16d9a285508348a810bcee7df3b7)