### PR TITLE
Don't ignore lengths of subchilds when calculating entity lengths

### DIFF
--- a/src/mdToDraftjs.js
+++ b/src/mdToDraftjs.js
@@ -90,7 +90,14 @@ const parseMdLine = (line, existingEntities, extraStyles = {}) => {
   };
 
   const getRawLength = children =>
-    children.reduce((prev, current) => prev + (current.value ? current.value.length : 0), 0);
+    children.reduce((prev, current) => {
+      if (current.value) {
+        return prev + current.value.length;
+      } else if (current.children && current.children.length) {
+        return prev + getRawLength(current.children);
+      }
+      return prev;
+    }, 0);
 
   const addLink = child => {
     const entityKey = Object.keys(entityMap).length;

--- a/test/mdToDraftjs.test.js
+++ b/test/mdToDraftjs.test.js
@@ -179,7 +179,7 @@ describe('mdToDraftjs', () => {
     mdToDraftjs(markdown).should.deep.equal(expectedDraftjs);
   });
 
-  it('converts two styles applied to the a link correctly', () => {
+  it('converts two styles applied outside a link correctly', () => {
     const markdown = '__*[label](http://example.com/here)*__';
     const expectedDraftjs = {
       blocks: [
@@ -196,7 +196,7 @@ describe('mdToDraftjs', () => {
           ],
           inlineStyleRanges: [
             {
-              length: 0,
+              length: 5,
               offset: 0,
               style: 'BOLD'
             },
@@ -204,6 +204,43 @@ describe('mdToDraftjs', () => {
               length: 5,
               offset: 0,
               style: 'ITALIC'
+            }
+          ]
+        }
+      ],
+      entityMap: {
+        0: {
+          type: 'LINK',
+          mutability: 'MUTABLE',
+          data: { url: 'http://example.com/here' }
+        }
+      }
+    };
+
+    const resultDraftJs = mdToDraftjs(markdown);
+    resultDraftJs.should.deep.equal(expectedDraftjs);
+  });
+
+  it('converts a style applied inside a link correctly', () => {
+    const markdown = '[la**b**el](http://example.com/here)';
+    const expectedDraftjs = {
+      blocks: [
+        {
+          text: 'label',
+          type: 'unstyled',
+          depth: 0,
+          entityRanges: [
+            {
+              key: 0,
+              length: 5,
+              offset: 0
+            }
+          ],
+          inlineStyleRanges: [
+            {
+              length: 1,
+              offset: 2,
+              style: 'BOLD'
             }
           ]
         }


### PR DESCRIPTION
Currently mdToDraftJS has a bug when considering nested styles/entities where it miscalculates lengths when things are nested.  For instance, it views markdown like

`[la**b**el](test.com)` and says that the link has length 4 and offset 0 (because it considers `**b**` to have 0 length).  

This PR adds 1 test and adjusts another test that had incorrect expectations to verify this behavior and adds a fix. 