### PR TITLE
Add return type to mdToDraftjs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,5 +4,8 @@ declare module 'draftjs-md-converter' {
     raw: RawDraftContentState,
     extraMarkdownDict?: { [key: string]: string }
   ): string;
-  export function mdToDraftjs(mdString: string, extraStyles?: { [key: string]: string });
+  export function mdToDraftjs(
+    mdString: string,
+    extraStyles?: { [key: string]: string }
+  ): RawDraftContentState;
 }


### PR DESCRIPTION
Fix usage with noImplicitAny compiler option.