### PR TITLE
Transpile to ES2015 syntax

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,7 +6,8 @@ const options = {
   bundle: true,
   minify: true,
   sourcemap: true,
-  external: ['path']
+  external: ['path'],
+  target: 'es2015'
 };
 (async () => {
   await esbuild


### PR DESCRIPTION
After #71 we stopped transpiling object spread properties, which are used [here](https://github.com/kadikraman/draftjs-md-converter/blob/master/src/draftjsToMd.js#L109). Setting `target` to `es2015` maintains support for less modern browsers (still dropping the EOL IE11 browser).

When not setting `target` esbuild would transpile to `esnext` which skips transpiling spread properties, among other things.

Ref: https://esbuild.github.io/content-types/#javascript